### PR TITLE
Partial sync with MediaWiki copy

### DIFF
--- a/File/Ogg.php
+++ b/File/Ogg.php
@@ -368,6 +368,10 @@ class File_Ogg
      */
     function _decodePageHeader($pageData, $pageOffset, $groupId)
     {
+        // Don't blindly substr() and unpack() if data is cut off
+        if (strlen($pageData) < 27)
+            return (false);
+
         // Extract the various bits and pieces found in each packet header.
         if (substr($pageData, 0, 4) != OGG_CAPTURE_PATTERN)
             return (false);
@@ -390,6 +394,11 @@ class File_Ogg
         $page_sequence   = unpack("Vdata", substr($pageData, 18, 4));
         $checksum        = unpack("Vdata", substr($pageData, 22, 4));
         $page_segments   = unpack("Cdata", substr($pageData, 26, 1));
+
+        // Header is extended with segment lengths; make sure we have data.
+        if (strlen($pageData) < 27 + $page_segments['data'])
+            return (false);
+
         $segments_total  = 0;
         for ($i = 0; $i < $page_segments['data']; ++$i) {
             $segment_length = unpack("Cdata", substr($pageData, 26 + ($i + 1), 1));

--- a/File/Ogg.php
+++ b/File/Ogg.php
@@ -120,8 +120,10 @@ define("OGG_ERROR_BAD_SERIAL",   3);
  */
 define("OGG_ERROR_UNDECODABLE",      4);
 
-require_once('PEAR.php');
-require_once('PEAR/Exception.php');
+class OggException extends Exception {
+    // Stub
+}
+
 require_once('File/Ogg/Bitstream.php');
 require_once("File/Ogg/Flac.php");
 require_once("File/Ogg/Speex.php");
@@ -198,18 +200,18 @@ class File_Ogg
     {
         clearstatcache();
         if (! file_exists($fileLocation)) {
-            throw new PEAR_Exception("Couldn't Open File.  Check File Path.", OGG_ERROR_INVALID_FILE);
+            throw new OggException("Couldn't Open File.  Check File Path.", OGG_ERROR_INVALID_FILE);
         }
 
         // Open this file as a binary, and split the file into streams.
         $this->_filePointer = fopen($fileLocation, "rb");
         if (!is_resource($this->_filePointer))
-            throw new PEAR_Exception("Couldn't Open File.  Check File Permissions.", OGG_ERROR_INVALID_FILE);
+            throw new OggException("Couldn't Open File.  Check File Permissions.", OGG_ERROR_INVALID_FILE);
 
         // Check for a stream at the start
         $magic = fread($this->_filePointer, strlen(OGG_CAPTURE_PATTERN));
         if ($magic !== OGG_CAPTURE_PATTERN) {
-            throw new PEAR_Exception("Couldn't read file: Incorrect magic number.", OGG_ERROR_UNDECODABLE);
+            throw new OggException("Couldn't read file: Incorrect magic number.", OGG_ERROR_UNDECODABLE);
         }
         fseek($this->_filePointer, 0, SEEK_SET);
 
@@ -250,7 +252,7 @@ class File_Ogg
         $bufferLength = ceil(array_sum($fields) / 8);
         $buffer = fread($file, $bufferLength);
         if (strlen($buffer) != $bufferLength) {
-            throw new PEAR_Exception('Unexpected end of file', OGG_ERROR_UNDECODABLE);
+            throw new OggException('Unexpected end of file', OGG_ERROR_UNDECODABLE);
         }
         $bytePos = 0;
         $bitPos = 0;
@@ -312,7 +314,7 @@ class File_Ogg
         $bufferLength = ceil(array_sum($fields) / 8);
         $buffer = fread($file, $bufferLength);
         if (strlen($buffer) != $bufferLength) {
-            throw new PEAR_Exception('Unexpected end of file', OGG_ERROR_UNDECODABLE);
+            throw new OggException('Unexpected end of file', OGG_ERROR_UNDECODABLE);
         }
 
         $bytePos = 0;
@@ -450,7 +452,7 @@ class File_Ogg
             }
             $page = $this->_decodePageHeader($pageData, $this_page_offset, $groupId);
             if ($page === false) {
-                throw new PEAR_Exception("Cannot decode Ogg file: Invalid page at offset $this_page_offset", OGG_ERROR_UNDECODABLE);
+                throw new OggException("Cannot decode Ogg file: Invalid page at offset $this_page_offset", OGG_ERROR_UNDECODABLE);
             }
 
             // Keep track of multiplexed groups
@@ -464,7 +466,7 @@ class File_Ogg
                 }
             }
             if ($openStreams < 0) {
-                throw new PEAR_Exception("Unexpected end of stream", OGG_ERROR_UNDECODABLE);
+                throw new OggException("Unexpected end of stream", OGG_ERROR_UNDECODABLE);
             }
 
             $this_page_offset = $page['body_finish'];
@@ -548,7 +550,7 @@ class File_Ogg
     function &getStream($streamSerial)
     {
         if (! array_key_exists($streamSerial, $this->_streams))
-                throw new PEAR_Exception("The stream number is invalid.", OGG_ERROR_BAD_SERIAL);
+                throw new OggException("The stream number is invalid.", OGG_ERROR_BAD_SERIAL);
 
         return $this->_streams[$streamSerial];
     }

--- a/File/Ogg/Flac.php
+++ b/File/Ogg/Flac.php
@@ -43,8 +43,32 @@ class File_Ogg_Flac extends File_Ogg_Media
         parent::__construct($streamSerial, $streamData, $filePointer);
         $this->_decodeHeader();
         $this->_decodeCommentsHeader();
-        $this->_streamLength    = $this->_streamInfo['total_samples']
-            / $this->_streamInfo['sample_rate'];
+
+        if ($this->_streamInfo['total_samples'] > 0) {
+            $this->_streamLength    = $this->_streamInfo['total_samples']
+                                    / $this->_streamInfo['sample_rate'];
+        } else {
+            // Header may have 0 for total_samples in which case we have to check.
+            // https://xiph.org/flac/format.html#metadata_block_streaminfo
+              $endSec =  $this->getSecondsFromGranulePos( $this->_lastGranulePos );
+              $startSec = $this->getSecondsFromGranulePos( $this->_firstGranulePos );
+
+            //make sure the offset is worth taking into account oggz_chop related hack
+            if( $startSec > 1) {
+                $this->_streamLength = $endSec - $startSec;
+                $this->_startOffset = $startSec;
+            } else {
+                $this->_streamLength = $endSec;
+            }
+        }
+
+        $this->_avgBitrate      = $this->_streamLength ? ($this->_streamSize * 8) / $this->_streamLength : 0;
+    }
+
+    function getSecondsFromGranulePos( $granulePos ){
+        return (( '0x' . substr( $granulePos, 0, 8 ) ) * pow(2, 32)
+              + ( '0x' . substr( $granulePos, 8, 8 ) ))
+              / $this->_streamInfo['sample_rate'];
     }
 
     /**

--- a/File/Ogg/Flac.php
+++ b/File/Ogg/Flac.php
@@ -66,16 +66,16 @@ class File_Ogg_Flac extends File_Ogg_Media
         // Check if this is the correct header.
         $packet = unpack("Cdata", fread($this->_filePointer, 1));
         if ($packet['data'] != 0x7f)
-            throw new PEAR_Exception("Stream Undecodable", OGG_ERROR_UNDECODABLE);
+            throw new OggException("Stream Undecodable", OGG_ERROR_UNDECODABLE);
     
         // The following four characters should be "FLAC".
         if (fread($this->_filePointer, 4) != 'FLAC')
-            throw new PEAR_Exception("Stream is undecodable due to a malformed header.", OGG_ERROR_UNDECODABLE);
+            throw new OggException("Stream is undecodable due to a malformed header.", OGG_ERROR_UNDECODABLE);
 
         $version = unpack("Cmajor/Cminor", fread($this->_filePointer, 2));
         $this->_version = "{$version['major']}.{$version['minor']}";
         if ($version['major'] > 1) {
-            throw new PEAR_Exception("Cannot decode a version {$version['major']} FLAC stream", OGG_ERROR_UNDECODABLE);
+            throw new OggException("Cannot decode a version {$version['major']} FLAC stream", OGG_ERROR_UNDECODABLE);
         }
         $h = File_Ogg::_readBigEndian( $this->_filePointer, 
             array(
@@ -125,7 +125,7 @@ class File_Ogg_Flac extends File_Ogg_Media
             )
         );
         if ($blockHeader['block_type'] != 4) {
-            throw new PEAR_Exception("Stream Undecodable", OGG_ERROR_UNDECODABLE);
+            throw new OggException("Stream Undecodable", OGG_ERROR_UNDECODABLE);
         }
         
         $this->_decodeBareCommentsHeader();

--- a/File/Ogg/Media.php
+++ b/File/Ogg/Media.php
@@ -86,12 +86,12 @@ abstract class File_Ogg_Media extends File_Ogg_Bitstream
             // Check if this is the correct header.
             $packet = unpack("Cdata", fread($this->_filePointer, 1));
             if ($packet['data'] != $packetType)
-                throw new PEAR_Exception("Stream Undecodable", OGG_ERROR_UNDECODABLE);
+                throw new OggException("Stream Undecodable", OGG_ERROR_UNDECODABLE);
         
             // The following six characters should be equal to getIdentificationString()
             $id = $this->getIdentificationString();
             if ($id !== '' && fread($this->_filePointer, strlen($id)) !== $id)
-                throw new PEAR_Exception("Stream is undecodable due to a malformed header.", OGG_ERROR_UNDECODABLE);
+                throw new OggException("Stream is undecodable due to a malformed header.", OGG_ERROR_UNDECODABLE);
         } // else seek only, no common header
     }
 

--- a/File/Ogg/Opus.php
+++ b/File/Ogg/Opus.php
@@ -82,7 +82,7 @@ class File_Ogg_Opus extends File_Ogg_Media
         fseek($this->_filePointer, $this->_streamData['pages'][0]['body_offset'], SEEK_SET);
         // The first 8 characters should be "OpusHead".
         if (fread($this->_filePointer, 8) != 'OpusHead')
-            throw new PEAR_Exception("Stream is undecodable due to a malformed header.", OGG_ERROR_UNDECODABLE);
+            throw new OggException("Stream is undecodable due to a malformed header.", OGG_ERROR_UNDECODABLE);
 
         $this->_header = File_Ogg::_readLittleEndian($this->_filePointer, array(
             'opus_version'          => 8,
@@ -120,7 +120,7 @@ class File_Ogg_Opus extends File_Ogg_Media
         $id = 'OpusTags';
         $this->_decodeCommonHeader(false, OGG_OPUS_COMMENTS_PAGE_OFFSET);
         if(fread($this->_filePointer, strlen($id)) !== $id)
-            throw new PEAR_Exception("Stream is undecodable due to a malformed header.", OGG_ERROR_UNDECODABLE);
+            throw new OggException("Stream is undecodable due to a malformed header.", OGG_ERROR_UNDECODABLE);
         $this->_decodeBareCommentsHeader();
     }
 }

--- a/File/Ogg/Speex.php
+++ b/File/Ogg/Speex.php
@@ -80,7 +80,7 @@ class File_Ogg_Speex extends File_Ogg_Media
         fseek($this->_filePointer, $this->_streamData['pages'][0]['body_offset'], SEEK_SET);
         // The first 8 characters should be "Speex   ".
         if (fread($this->_filePointer, 8) != 'Speex   ')
-            throw new PEAR_Exception("Stream is undecodable due to a malformed header.", OGG_ERROR_UNDECODABLE);
+            throw new OggException("Stream is undecodable due to a malformed header.", OGG_ERROR_UNDECODABLE);
 
         $this->_version = fread($this->_filePointer, 20);
         $this->_header = File_Ogg::_readLittleEndian($this->_filePointer, array(

--- a/File/Ogg/Theora.php
+++ b/File/Ogg/Theora.php
@@ -117,27 +117,27 @@ class File_Ogg_Theora extends File_Ogg_Media
             'KFGSHIFT' => 5,
             'PF' => 2));
         if ( !$h ) {
-            throw new PEAR_Exception("Stream is undecodable due to a truncated header.", OGG_ERROR_UNDECODABLE);
+            throw new OggException("Stream is undecodable due to a truncated header.", OGG_ERROR_UNDECODABLE);
         }
 
         // Theora version
         // Seems overly strict but this is what the spec says
         // VREV is for backwards-compatible changes, apparently
         if ( $h['VMAJ'] != 3 || $h['VMIN'] != 2 ) {
-            throw new PEAR_Exception("Stream is undecodable due to an invalid theora version.", OGG_ERROR_UNDECODABLE);
+            throw new OggException("Stream is undecodable due to an invalid theora version.", OGG_ERROR_UNDECODABLE);
         }
         $this->_theoraVersion = "{$h['VMAJ']}.{$h['VMIN']}.{$h['VREV']}";
 
         // Frame height/width
         if ( !$h['FMBW'] || !$h['FMBH'] ) {
-            throw new PEAR_Exception("Stream is undecodable because it has frame size of zero.", OGG_ERROR_UNDECODABLE);
+            throw new OggException("Stream is undecodable because it has frame size of zero.", OGG_ERROR_UNDECODABLE);
         }
         $this->_frameWidth = $h['FMBW'] * 16;
         $this->_frameHeight = $h['FMBH'] * 16;
 
         // Picture height/width
         if ( $h['PICW'] > $this->_frameWidth || $h['PICH'] > $this->_frameHeight ) {
-            throw new PEAR_Exception("Stream is undecodable because the picture width is greater than the frame width.", OGG_ERROR_UNDECODABLE);
+            throw new OggException("Stream is undecodable because the picture width is greater than the frame width.", OGG_ERROR_UNDECODABLE);
         }
         $this->_pictureWidth = $h['PICW'];
         $this->_pictureHeight = $h['PICH'];

--- a/File/Ogg/Vorbis.php
+++ b/File/Ogg/Vorbis.php
@@ -228,17 +228,17 @@ class File_Ogg_Vorbis extends File_Ogg_Media
         if ($h['vorbis_version'] == 0)
             $this->_version = $h['vorbis_version'];
         else
-            throw new PEAR_Exception("Stream is undecodable due to an invalid vorbis stream version.", OGG_VORBIS_ERROR_UNDECODABLE);
+            throw new OggException("Stream is undecodable due to an invalid vorbis stream version.", OGG_VORBIS_ERROR_UNDECODABLE);
 
         // The number of channels MUST be greater than 0.
         if ($h['audio_channels'] == 0)
-            throw new PEAR_Exception("Stream is undecodable due to zero channels.", OGG_VORBIS_ERROR_UNDECODABLE);
+            throw new OggException("Stream is undecodable due to zero channels.", OGG_VORBIS_ERROR_UNDECODABLE);
         else
             $this->_channels = $h['audio_channels'];
 
         // The sample rate MUST be greater than 0.
         if ($h['audio_sample_rate'] == 0)
-            throw new PEAR_Exception("Stream is undecodable due to a zero sample rate.", OGG_VORBIS_ERROR_UNDECODABLE);
+            throw new OggException("Stream is undecodable due to a zero sample rate.", OGG_VORBIS_ERROR_UNDECODABLE);
         else
             $this->_sampleRate = $h['audio_sample_rate'];
 
@@ -253,23 +253,23 @@ class File_Ogg_Vorbis extends File_Ogg_Media
         // blocksize_0 MUST be a valid blocksize.
         $blocksize_0 = pow(2, $h['blocksize_0']);
         if (FALSE == in_array($blocksize_0, $valid_block_sizes))
-            throw new PEAR_Exception("Stream is undecodable because blocksize_0 is $blocksize_0, which is not a valid size.", OGG_VORBIS_ERROR_UNDECODABLE);
+            throw new OggException("Stream is undecodable because blocksize_0 is $blocksize_0, which is not a valid size.", OGG_VORBIS_ERROR_UNDECODABLE);
 
         // Extract bits 5 to 8 from the character data.
         // blocksize_1 MUST be a valid blocksize.
         $blocksize_1 = pow(2, $h['blocksize_1']);
         if (FALSE == in_array($blocksize_1, $valid_block_sizes))
-            throw new PEAR_Exception("Stream is undecodable because blocksize_1 is not a valid size.", OGG_VORBIS_ERROR_UNDECODABLE);
+            throw new OggException("Stream is undecodable because blocksize_1 is not a valid size.", OGG_VORBIS_ERROR_UNDECODABLE);
 
         // blocksize 0 MUST be less than or equal to blocksize 1.
         if ($blocksize_0 > $blocksize_1)
-            throw new PEAR_Exception("Stream is undecodable because blocksize_0 is not less than or equal to blocksize_1.", OGG_VORBIS_ERROR_UNDECODABLE);
+            throw new OggException("Stream is undecodable because blocksize_0 is not less than or equal to blocksize_1.", OGG_VORBIS_ERROR_UNDECODABLE);
 
         // The framing bit MUST be set to mark the end of the identification header.
         // Some encoders are broken though -- TS
         /*
         if ($h['framing_flag'] == 0)
-            throw new PEAR_Exception("Stream in undecodable because the framing bit is not non-zero.", OGG_VORBIS_ERROR_UNDECODABLE);
+            throw new OggException("Stream in undecodable because the framing bit is not non-zero.", OGG_VORBIS_ERROR_UNDECODABLE);
          */
 
         $this->_idHeader = $h;
@@ -288,7 +288,7 @@ class File_Ogg_Vorbis extends File_Ogg_Media
         // The framing bit MUST be set to mark the end of the comments header.
         $framing_bit = unpack("Cdata", fread($this->_filePointer, 1));
         if ($framing_bit['data'] != 1)
-            throw new PEAR_Exception("Stream Undecodable", OGG_VORBIS_ERROR_UNDECODABLE);
+            throw new OggException("Stream Undecodable", OGG_VORBIS_ERROR_UNDECODABLE);
     }
 
     /**


### PR DESCRIPTION
* drop PEAR_Exception dependency to make reuse easier outside classic PEAR environment
* merge off-tree fix when encountering Ogg pages chopped at odd boundaries
* calculate length of FLAC files when header lists 0 (unknown)
