### PR TITLE
PHP7 no longer convert 0x strings to numbers automatically

### DIFF
--- a/File/Ogg/Flac.php
+++ b/File/Ogg/Flac.php
@@ -66,8 +66,8 @@ class File_Ogg_Flac extends File_Ogg_Media
     }
 
     function getSecondsFromGranulePos( $granulePos ){
-        return (( '0x' . substr( $granulePos, 0, 8 ) ) * pow(2, 32)
-              + ( '0x' . substr( $granulePos, 8, 8 ) ))
+        return (intval(substr( $granulePos, 0, 8 ), 16 ) * pow(2, 32)
+              + intval(substr( $granulePos, 8, 8 ), 16 ))
               / $this->_streamInfo['sample_rate'];
     }
 

--- a/File/Ogg/Opus.php
+++ b/File/Ogg/Opus.php
@@ -58,8 +58,8 @@ class File_Ogg_Opus extends File_Ogg_Media
     }
 
     function getSecondsFromGranulePos( $granulePos ){
-        return (( '0x' . substr( $granulePos, 0, 8 ) ) * pow(2, 32)
-            + ( '0x' . substr( $granulePos, 8, 8 ) )
+        return (intval(substr( $granulePos, 0, 8 ), 16 ) * pow(2, 32)
+            + intval(substr( $granulePos, 8, 8 ), 16 )
             - $this->_header['pre_skip'])
             / 48000;
     }

--- a/File/Ogg/Speex.php
+++ b/File/Ogg/Speex.php
@@ -44,13 +44,13 @@ class File_Ogg_Speex extends File_Ogg_Media
         $this->_decodeHeader();
         $this->_decodeCommentsHeader();
         $endSec =
-            (( '0x' . substr( $this->_lastGranulePos, 0, 8 ) ) * pow(2, 32) 
-            + ( '0x' . substr( $this->_lastGranulePos, 8, 8 ) ))
+            (intval(substr( $this->_lastGranulePos, 0, 8 ), 16 ) * pow(2, 32)
+            + intval( substr( $this->_lastGranulePos, 8, 8 ), 16 ))
             / $this->_header['rate'];
      
          $startSec	 =        
-            (( '0x' . substr( $this->_firstGranulePos, 0, 8 ) ) * pow(2, 32) 
-            + ( '0x' . substr( $this->_firstGranulePos, 8, 8 ) ))
+            (intval(substr( $this->_firstGranulePos, 0, 8 ), 16 ) * pow(2, 32)
+            + intval(substr( $this->_firstGranulePos, 8, 8 ), 16 ))
             / $this->_header['rate'];
             
          //make sure the offset is worth taking into account oggz_chop related hack

--- a/File/Ogg/Vorbis.php
+++ b/File/Ogg/Vorbis.php
@@ -186,8 +186,8 @@ class File_Ogg_Vorbis extends File_Ogg_Media
         $this->_avgBitrate      = $this->_streamLength ? ($this->_streamSize * 8) / $this->_streamLength : 0;
     }
 	function getSecondsFromGranulePos( $granulePos ){
-		return (( '0x' . substr( $granulePos, 0, 8 ) ) * pow(2, 32)
-            + ( '0x' . substr( $granulePos, 8, 8 ) ))
+		return (intval(substr( $granulePos, 0, 8 ), 16) * pow(2, 32)
+            + intval( substr( $granulePos, 8, 8 ), 16 ))
             / $this->_idHeader['audio_sample_rate'];
 	}
     /**


### PR DESCRIPTION
Use intval with base 16 instead.

This fixes https://phabricator.wikimedia.org/T160536